### PR TITLE
Elmolesto/fix/change fecha termino

### DIFF
--- a/app/views/trabajos/_form.html.erb
+++ b/app/views/trabajos/_form.html.erb
@@ -43,7 +43,7 @@
       <td>Factura</td>
     </tr>
     <tr class>
-        <td><%= f.input :fecha_termino, label: false, collection: ["Mar-20", "Abr-20", "May-20", "Jun-20", "Jul-20", "Ago-20", "Sep-20", "Oct-20", "Nov-20", "Dic-20"] %></td>
+        <td><%= f.input :fecha_termino, label: false, discard_year: true, discard_day: true, order: [:month] %></td>
         <td><%= f.input :avance, label: false, collection: ["Cotizada", "Aprobada", "En ejecucción", "Terminado", "Facturado", "Cancelada"] %></td>
         <td><%= f.input :op, label: false %></td>
         <td><%= f.input :factura, label: false %></td>

--- a/db/migrate/20200829061246_change_fecha_termino_to_date.rb
+++ b/db/migrate/20200829061246_change_fecha_termino_to_date.rb
@@ -1,0 +1,10 @@
+class ChangeFechaTerminoToDate < ActiveRecord::Migration[6.0]
+  def up
+    execute "UPDATE trabajos SET fecha_termino = translate(fecha_termino, 'Abr,Ago', 'Apr,Aug')"
+    change_column :trabajos, :fecha_termino, "date USING TO_DATE(fecha_termino, 'Mon-YY')"
+  end
+
+  def down 
+    change_column :trabajos, :fecha_termino, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_05_162339) do
+ActiveRecord::Schema.define(version: 2020_08_29_061246) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -409,7 +409,7 @@ ActiveRecord::Schema.define(version: 2020_08_05_162339) do
     t.string "ito"
     t.string "descripcion"
     t.integer "total"
-    t.string "fecha_termino"
+    t.date "fecha_termino"
     t.string "avance"
     t.integer "op"
     t.integer "factura"


### PR DESCRIPTION
Migración:
Convierto los strings de fechas a inglés solo para Abril y Agosto, ej: "Abr-20" se traduce a "Apr-20".
Cambio el tipo de la columna "fecha_termino" a date, casteando los datos como fechas.

Formulario:
En el dropdown muestro solo los meses.